### PR TITLE
Import AbstractSet from Base

### DIFF
--- a/src/LearnBase.jl
+++ b/src/LearnBase.jl
@@ -126,11 +126,7 @@ function learn end
 function learn! end
 
 
-"""
-Base class for defining sets of numbers. Used in specifying
-the input and output domains of transformations and losses.
-"""
-abstract AbstractSet
+import Base: AbstractSet
 
 "A continuous range (inclusive) between a lo and a hi"
 immutable IntervalSet{T<:Number} <: AbstractSet


### PR DESCRIPTION
As I brought up here -- https://github.com/JuliaML/Losses.jl/issues/35 -- I am a bit uneasy how we are defining Sets in LearnBase that aren't aware of `Base.Set` and `Base.AbstractSet`. This PR makes `ContinuousSet` and friends subtypes of `Base.AbstractSet` which I think makes more sense. I do have a few reservations:
1. `AbstractSet` is not exported from Base. It could be deleted or changed in the future.
2. I don't have a complete understanding of what the contributors to Base intend `AbstractSet` to mean... Is it the same definition as we intend? I think so, but I'm not positive.

cc @tbreloff @Evizero  
