### PR TITLE
add ObsDim and getobs

### DIFF
--- a/src/LearnBase.jl
+++ b/src/LearnBase.jl
@@ -131,6 +131,135 @@ function update! end
 function learn end
 function learn! end
 
+"""
+    getobs(data, [idx], [obsdim])
+
+Returns the observations corresponding to the observation-index `idx`.
+Note that `idx` can be of type `Int` or `AbstractVector`.
+
+If it makes sense for the type of `data`, `obsdim` can be used to
+specify which dimension of `data` denotes the observations.
+It can be specified in a typestable manner as a positional argument
+(see `?ObsDim`), or more conveniently as a smart keyword argument.
+"""
+function getobs end
+
+"""
+    getobs!(buffer, data, [idx], [obsdim])
+
+Inplace version of `getobs(data, idx, obsdim)`. If this method is
+defined for the type of `data`, then `buffer` will be used to store
+the result instead of allocating a dedicated object.
+
+Note: In the case no such method is provided for the type of `data`,
+then `buffer` will be **ignored** and the result of `getobs` returned.
+This could be because the type of `data` may not lend itself to the
+concept of `copy!`. Thus supporting a custom `getobs!(::MyType, ...)`
+is optional and not required.
+"""
+function getobs! end
+
+# --------------------------------------------------------------------
+
+"""
+    datasubset(data, [indices], [obsdim])
+
+Returns a lazy subset of the observations in `data` that correspond
+to the given `indices`. No data will be copied except of the indices.
+It is similar to calling `DataSubset(data, [indices], [obsdim])`,
+but returns a `SubArray` if the type of `data` is `Array` or `SubArray`.
+Furthermore, this function may be extended for custom types of `data`
+that also want to provide their own subset-type.
+
+If instead you want to get the subset of observations corresponding
+to the given `indices` in their native type, use `getobs`.
+
+The optional (keyword) parameter `obsdim` allows one to specify which
+dimension denotes the observations. see `ObsDim` for more detail.
+
+see `DataSubset` for more information.
+"""
+function datasubset end
+
+"""
+    default_obsdim(data)
+
+The specify the default obsdim for a specific type of data.
+Defaults to `ObsDim.Undefined()`
+"""
+function default_obsdim end
+
+# just for dispatch for those who care to
+"see `?ObsDim`"
+abstract ObsDimension
+
+"""
+    module ObsDim
+
+Singleton types to define which dimension of some data structure
+(e.g. some `Array`) denotes the observations.
+
+- `ObsDim.First()`
+- `ObsDim.Last()`
+- `ObsDim.Contant(dim)`
+
+Used for efficient dispatching
+"""
+module ObsDim
+    using ..LearnBase.ObsDimension
+
+    """
+    Default value for most functions. Denotes that the concept of
+    an observation dimension is not defined for the given data.
+    """
+    immutable Undefined <: ObsDimension end
+
+    """
+        ObsDim.Last <: ObsDimension
+
+    Defines that the last dimension denotes the observations
+    """
+    immutable Last <: ObsDimension end
+
+    """
+        ObsDim.Constant{DIM} <: ObsDimension
+
+    Defines that the dimension `DIM` denotes the observations
+    """
+    immutable Constant{DIM} <: ObsDimension end
+    Constant(dim::Int) = Constant{dim}()
+
+    """
+        ObsDim.First <: ObsDimension
+
+    Defines that the first dimension denotes the observations
+    """
+    typealias First Constant{1}
+end
+
+# interval convenience function; not exported
+obs_dim(dim) = throw(ArgumentError("Unknown way to specify a obsdim: $dim"))
+obs_dim(dim::ObsDimension) = dim
+obs_dim(::Void) = ObsDim.Undefined()
+obs_dim(dim::Int) = ObsDim.Constant(dim)
+obs_dim(dim::String) = obs_dim(Symbol(lowercase(dim)))
+obs_dim(dims::Tuple) = map(obs_dim, dims)
+function obs_dim(dim::Symbol)
+    if dim == :first || dim == :begin
+        ObsDim.First()
+    elseif dim == Symbol("end") || dim == :last
+        ObsDim.Last()
+    elseif dim == Symbol("nothing") || dim == :none || dim == :null || dim == :na || dim == :undefined
+        ObsDim.Undefined()
+    else
+        throw(ArgumentError("Unknown way to specify a obsdim: $dim"))
+    end
+end
+
+@noinline default_obsdim(data) = ObsDim.Undefined()
+@noinline default_obsdim(A::AbstractArray) = ObsDim.Last()
+default_obsdim(tup::Tuple) = map(default_obsdim, tup)
+
 
 import Base: AbstractSet
 
@@ -291,6 +420,11 @@ export
 
     # Base
     issymmetric,
+
+    getobs,
+    getobs!,
+    datasubset,
+    ObsDim,
 
     # StatsBase
     fit,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,9 +61,19 @@ using Base.Test
 
 @test typeof(issymmetric) <: Function
 
+@test typeof(getobs) <: Function
+@test typeof(getobs!) <: Function
+@test typeof(datasubset) <: Function
+
 @test typeof(fit) <: Function
 @test typeof(fit!) <: Function
 @test typeof(nobs) <: Function
+
+@test ObsDim.Constant <: LearnBase.ObsDimension
+@test ObsDim.First <: LearnBase.ObsDimension
+@test ObsDim.Last <: LearnBase.ObsDimension
+@test ObsDim.Undefined <: LearnBase.ObsDimension
+@test typeof(ObsDim.Constant(2)) <: ObsDim.Constant{2}
 
 # Test that LearnBase reuses StatsBase functions
 using StatsBase


### PR DESCRIPTION
This adds the submodule `ObsDim` which holds objects that can describe which dimension of some object (most notably arrays) describes the observations. 

I move this here now from MLDataUtils, because I need them in MLLabelUtils as well for `OneOfK` encoding