### PR TITLE
RFC: adding scaled (or something better?)

### DIFF
--- a/src/LearnBase.jl
+++ b/src/LearnBase.jl
@@ -75,6 +75,7 @@ function value_grad end
 function value_grad! end
 function prox end
 function prox! end
+function scaled end
 
 "Return the gradient of the learnable parameters w.r.t. some objective"
 function grad end


### PR DESCRIPTION
I'll be removing tuning parameters from penalties (see https://github.com/JuliaML/PenaltyFunctions.jl/issues/10), but adding in scaled versions, similar to @Evizero's scaled loss types.  It'd be nice if Losses and Penalties could share a function which returns a scaled version.