### PR TITLE
move dataview and dataiterator base classes here from MLDataUtils

### DIFF
--- a/src/LearnBase.jl
+++ b/src/LearnBase.jl
@@ -190,6 +190,101 @@ function targets end
 # --------------------------------------------------------------------
 
 """
+    abstract DataView{TElem, TData} <: AbstractVector{TElem}
+
+Baseclass for all vector-like views of some data structure.
+This allow for example to see some design matrix as a vector of
+individual observation-vectors instead of one matrix.
+
+see `MLDataPattern.ObsView` and `MLDataPattern.BatchView` for examples.
+"""
+@compat abstract type DataView{TElem, TData} <: AbstractVector{TElem} end
+
+"""
+    abstract AbstractObsView{TElem, TData} <: DataView{TElem, TData}
+
+Baseclass for all vector-like views of some data structure,
+that views it as some form or vector of observations.
+
+see `MLDataPattern.ObsView` for a concrete example.
+"""
+@compat abstract type AbstractObsView{TElem, TData} <: DataView{TElem, TData} end
+
+"""
+    abstract AbstractBatchView{TElem, TData} <: DataView{TElem, TData}
+
+Baseclass for all vector-like views of some data structure,
+that views it as some form or vector of equally sized batches.
+
+see `MLDataPattern.BatchView` for a concrete example.
+"""
+@compat abstract type AbstractBatchView{TElem, TData} <: DataView{TElem, TData} end
+
+# --------------------------------------------------------------------
+
+"""
+    abstract DataIterator{TElem,TData}
+
+Baseclass for all types that iterate over a `data` source
+in some manner. The total number of observations may or may
+not be known or defined and in general there is no contract that
+`getobs` or `nobs` has to be supported by the type of `data`.
+Furthermore, `length` should be used to query how many elements
+the iterator can provide, while `nobs` may return the underlying
+true amount of observations available (if known).
+
+see `MLDataPattern.RandomObs`, `MLDataPattern.RandomBatches`
+"""
+@compat abstract type DataIterator{TElem,TData} end
+
+"""
+    abstract ObsIterator{TElem,TData} <: DataIterator{TElem,TData}
+
+Baseclass for all types that iterate over some data source
+one observation at a time.
+
+```julia
+using MLDataPattern
+@assert typeof(RandomObs(X)) <: ObsIterator
+
+for x in RandomObs(X)
+    # ...
+end
+```
+
+see `MLDataPattern.RandomObs`
+"""
+@compat abstract type ObsIterator{TElem,TData} <: DataIterator{TElem,TData} end
+
+"""
+    abstract BatchIterator{TElem,TData} <: DataIterator{TElem,TData}
+
+Baseclass for all types that iterate over of some data source one
+batch at a time.
+
+```julia
+@assert typeof(RandomBatches(X, size=10)) <: BatchIterator
+
+for x in RandomBatches(X, size=10)
+    @assert nobs(x) == 10
+    # ...
+end
+```
+
+see `MLDataPattern.RandomBatches`
+"""
+@compat abstract type BatchIterator{TElem,TData} <: DataIterator{TElem,TData} end
+
+# --------------------------------------------------------------------
+
+# just for dispatch for those who care to
+@compat const AbstractDataIterator{E,T}  = Union{DataIterator{E,T}, DataView{E,T}}
+@compat const AbstractObsIterator{E,T}   = Union{ObsIterator{E,T},  AbstractObsView{E,T}}
+@compat const AbstractBatchIterator{E,T} = Union{BatchIterator{E,T},AbstractBatchView{E,T}}
+
+# --------------------------------------------------------------------
+
+"""
     datasubset(data, [indices], [obsdim])
 
 Returns a lazy subset of the observations in `data` that correspond
@@ -457,6 +552,18 @@ export
     ObsDim,
 
     targets,
+
+    AbstractDataIterator,
+        AbstractObsIterator,
+        AbstractBatchIterator,
+
+    DataView,
+        AbstractObsView,
+        AbstractBatchView,
+
+    DataIterator,
+        ObsIterator,
+        BatchIterator,
 
     # StatsBase
     fit,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,6 +71,30 @@ using Base.Test
 @test typeof(LearnBase.gettarget) <: Function
 @test typeof(LearnBase.gettargets) <: Function
 
+@test DataView <: AbstractVector
+@test DataView <: AbstractDataIterator
+@test DataView{Int} <: AbstractVector{Int}
+@test DataView{Int,Vector{Int}} <: AbstractDataIterator{Int,Vector{Int}}
+@test AbstractObsView <: DataView
+@test AbstractObsView <: AbstractObsIterator
+@test AbstractObsView{Int,Vector{Int}} <: DataView{Int,Vector{Int}}
+@test AbstractObsView{Int,Vector{Int}} <: AbstractObsIterator{Int,Vector{Int}}
+@test AbstractBatchView <: DataView
+@test AbstractBatchView <: AbstractBatchIterator
+@test AbstractBatchView{Int,Vector{Int}} <: DataView{Int,Vector{Int}}
+@test AbstractBatchView{Int,Vector{Int}} <: AbstractBatchIterator{Int,Vector{Int}}
+
+@test DataIterator <: AbstractDataIterator
+@test DataIterator{Int,Vector{Int}} <: AbstractDataIterator{Int,Vector{Int}}
+@test ObsIterator <: DataIterator
+@test ObsIterator <: AbstractObsIterator
+@test ObsIterator{Int,Vector{Int}} <: DataIterator{Int,Vector{Int}}
+@test ObsIterator{Int,Vector{Int}} <: AbstractObsIterator{Int,Vector{Int}}
+@test BatchIterator <: DataIterator
+@test BatchIterator <: AbstractBatchIterator
+@test BatchIterator{Int,Vector{Int}} <: DataIterator{Int,Vector{Int}}
+@test BatchIterator{Int,Vector{Int}} <: AbstractBatchIterator{Int,Vector{Int}}
+
 @test typeof(fit) <: Function
 @test typeof(fit!) <: Function
 @test typeof(nobs) <: Function


### PR DESCRIPTION
I opted for docstrings for the types, since in contrast to functions they are fully qualified. 

The motivation for the types being here is that packages can extend the patterns without having anything but `LearnBase` in their `REQUIRE`