### PR TITLE
Remove deprecated syntax, get ready for 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
   - nightly
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
   - nightly
 notifications:
   email: true

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.5
+julia 0.6
 StatsBase 0.17.0
 Compat 0.18

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
-julia 0.6
+julia 0.7-
 StatsBase 0.17.0
 Compat 0.18
+Unicode

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.7-
 StatsBase 0.17.0
-Compat 0.18
 Unicode

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
 julia 0.7-
 StatsBase 0.17.0
-Unicode

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/LearnBase.jl
+++ b/src/LearnBase.jl
@@ -4,6 +4,7 @@ module LearnBase
 
 # Only reexport required functions by default
 import StatsBase: nobs, fit, fit!, predict, params, params!
+import Unicode: lowercase
 using Compat
 
 import Base.issymmetric
@@ -372,7 +373,7 @@ end
 
 Base.convert(::Type{ObsDimension}, dim) = throw(ArgumentError("Unknown way to specify a obsdim: $dim"))
 Base.convert(::Type{ObsDimension}, dim::ObsDimension) = dim
-Base.convert(::Type{ObsDimension}, ::Void) = ObsDim.Undefined()
+Base.convert(::Type{ObsDimension}, ::Nothing) = ObsDim.Undefined()
 Base.convert(::Type{ObsDimension}, dim::Int) = ObsDim.Constant(dim)
 Base.convert(::Type{ObsDimension}, dim::String) = convert(ObsDimension, Symbol(lowercase(dim)))
 Base.convert(::Type{ObsDimension}, dims::Tuple) = map(d->convert(ObsDimension, d), dims)
@@ -387,8 +388,6 @@ function Base.convert(::Type{ObsDimension}, dim::Symbol)
         throw(ArgumentError("Unknown way to specify a obsdim: $dim"))
     end
 end
-
-@deprecate obs_dim(dim) convert(ObsDimension, dim)
 
 default_obsdim(data) = ObsDim.Undefined()
 default_obsdim(A::AbstractArray) = ObsDim.Last()
@@ -409,7 +408,7 @@ end
 
 # numeric interval
 randtype(s::IntervalSet{<:Number}) = Float64
-Base.rand(s::IntervalSet{<:Number}, dims::Integer...) = rand(dims...) * (s.hi - s.lo) + s.lo
+Base.rand(s::IntervalSet{<:Number}, dims::Integer...) = rand(dims...) .* (s.hi .- s.lo) .+ s.lo
 Base.in(x::Number, s::IntervalSet{<:Number}) = s.lo <= x <= s.hi
 Base.length(s::IntervalSet{<:Number}) = 1
 
@@ -439,7 +438,7 @@ function Base.rand(sets::AbstractArray{S}) where {S<:AbstractSet}
     eltype(randtype(sets))[rand(s) for s in sets]
 end
 function Base.rand(sets::AbstractArray{S}, dim1::Integer, dims::Integer...) where {S<:AbstractSet}
-    A = Array{randtype(sets)}(dim1, dims...)
+    A = Array{randtype(sets)}(uninitialized, dim1, dims...)
     for i in eachindex(A)
         A[i] = rand(sets)
     end
@@ -462,7 +461,7 @@ Base.rand(sets::TupleSet, ::Type{Vector}) = eltype(randtype(sets, Vector))[rand(
 randtype(sets::TupleSet, ::Type{Tuple}) = Tuple{map(randtype, sets.sets)...}
 Base.rand(sets::TupleSet, ::Type{Tuple}) = map(rand, sets.sets)
 function Base.rand(sets::TupleSet, ::Type{OT}, dim1::Integer, dims::Integer...) where {OT}
-    A = Array{randtype(sets, OT)}(dim1, dims...)
+    A = Array{randtype(sets, OT)}(uninitialized, dim1, dims...)
     for i in eachindex(A)
         A[i] = rand(sets, OT)
     end

--- a/src/LearnBase.jl
+++ b/src/LearnBase.jl
@@ -5,7 +5,6 @@ module LearnBase
 # Only reexport required functions by default
 import StatsBase: nobs, fit, fit!, predict, params, params!
 import Unicode: lowercase
-using Compat
 
 import Base.issymmetric
 
@@ -13,14 +12,14 @@ import Base.issymmetric
 Baseclass for any kind of cost. Notable examples for
 costs are `Loss` and `Penalty`.
 """
-@compat abstract type Cost end
+abstract type Cost end
 
 """
 Baseclass for all losses. A loss is some (possibly simplified)
 function `L(features, targets, outputs)`, where `outputs` are the
 result of some function `f(features)`.
 """
-@compat abstract type Loss <: Cost end
+abstract type Loss <: Cost end
 
 """
 A loss is considered **supervised**, if all the information needed
@@ -28,14 +27,14 @@ to compute `L(features, targets, outputs)` are contained in
 `targets` and `outputs`, and thus allows for the simplification
 `L(targets, outputs)`.
 """
-@compat abstract type SupervisedLoss <: Loss end
+abstract type SupervisedLoss <: Loss end
 
 """
 A supervised loss, where the targets are in {-1, 1}, and which
 can be simplified to `L(targets, outputs) = L(targets * outputs)`
 is considered **margin-based**.
 """
-@compat abstract type MarginLoss <: SupervisedLoss end
+abstract type MarginLoss <: SupervisedLoss end
 
 
 """
@@ -43,7 +42,7 @@ A supervised loss that can be simplified to
 `L(targets, outputs) = L(targets - outputs)` is considered
 distance-based.
 """
-@compat abstract type DistanceLoss <: SupervisedLoss end
+abstract type DistanceLoss <: SupervisedLoss end
 
 """
 A loss is considered **unsupervised**, if all the information needed
@@ -51,9 +50,9 @@ to compute `L(features, targets, outputs)` are contained in
 `features` and `outputs`, and thus allows for the simplification
 `L(features, outputs)`.
 """
-@compat abstract type UnsupervisedLoss <: Loss end
+abstract type UnsupervisedLoss <: Loss end
 
-@compat abstract type Penalty <: Cost end
+abstract type Penalty <: Cost end
 
 function scaled end
 
@@ -105,9 +104,9 @@ Anything that takes an input and performs some kind
 of function to produce an output. For example a linear
 prediction function.
 """
-@compat abstract type Transformation end
-@compat abstract type StochasticTransformation <: Transformation end
-@compat abstract type Learnable <: Transformation end
+abstract type Transformation end
+abstract type StochasticTransformation <: Transformation end
+abstract type Learnable <: Transformation end
 
 function transform end
 "Do a forward pass, and return the output"
@@ -118,7 +117,7 @@ Baseclass for any prediction model that can be minimized.
 This means that an object of a subclass contains all the
 information needed to compute its own current loss.
 """
-@compat abstract type Minimizable <: Learnable end
+abstract type Minimizable <: Learnable end
 
 function update end
 function update! end
@@ -215,7 +214,7 @@ individual observation-vectors instead of one matrix.
 
 see `MLDataPattern.ObsView` and `MLDataPattern.BatchView` for examples.
 """
-@compat abstract type DataView{TElem, TData} <: AbstractVector{TElem} end
+abstract type DataView{TElem, TData} <: AbstractVector{TElem} end
 
 """
     abstract AbstractObsView{TElem, TData} <: DataView{TElem, TData}
@@ -225,7 +224,7 @@ that views it as some form or vector of observations.
 
 see `MLDataPattern.ObsView` for a concrete example.
 """
-@compat abstract type AbstractObsView{TElem, TData} <: DataView{TElem, TData} end
+abstract type AbstractObsView{TElem, TData} <: DataView{TElem, TData} end
 
 """
     abstract AbstractBatchView{TElem, TData} <: DataView{TElem, TData}
@@ -235,7 +234,7 @@ that views it as some form or vector of equally sized batches.
 
 see `MLDataPattern.BatchView` for a concrete example.
 """
-@compat abstract type AbstractBatchView{TElem, TData} <: DataView{TElem, TData} end
+abstract type AbstractBatchView{TElem, TData} <: DataView{TElem, TData} end
 
 # --------------------------------------------------------------------
 
@@ -252,7 +251,7 @@ true amount of observations available (if known).
 
 see `MLDataPattern.RandomObs`, `MLDataPattern.RandomBatches`
 """
-@compat abstract type DataIterator{TElem,TData} end
+abstract type DataIterator{TElem,TData} end
 
 """
     abstract ObsIterator{TElem,TData} <: DataIterator{TElem,TData}
@@ -271,7 +270,7 @@ end
 
 see `MLDataPattern.RandomObs`
 """
-@compat abstract type ObsIterator{TElem,TData} <: DataIterator{TElem,TData} end
+abstract type ObsIterator{TElem,TData} <: DataIterator{TElem,TData} end
 
 """
     abstract BatchIterator{TElem,TData} <: DataIterator{TElem,TData}
@@ -290,14 +289,14 @@ end
 
 see `MLDataPattern.RandomBatches`
 """
-@compat abstract type BatchIterator{TElem,TData} <: DataIterator{TElem,TData} end
+abstract type BatchIterator{TElem,TData} <: DataIterator{TElem,TData} end
 
 # --------------------------------------------------------------------
 
 # just for dispatch for those who care to
-@compat const AbstractDataIterator{E,T}  = Union{DataIterator{E,T}, DataView{E,T}}
-@compat const AbstractObsIterator{E,T}   = Union{ObsIterator{E,T},  AbstractObsView{E,T}}
-@compat const AbstractBatchIterator{E,T} = Union{BatchIterator{E,T},AbstractBatchView{E,T}}
+const AbstractDataIterator{E,T}  = Union{DataIterator{E,T}, DataView{E,T}}
+const AbstractObsIterator{E,T}   = Union{ObsIterator{E,T},  AbstractObsView{E,T}}
+const AbstractBatchIterator{E,T} = Union{BatchIterator{E,T},AbstractBatchView{E,T}}
 
 # --------------------------------------------------------------------
 
@@ -325,7 +324,7 @@ function default_obsdim end
 
 # just for dispatch for those who care to
 "see `?ObsDim`"
-@compat abstract type ObsDimension end
+abstract type ObsDimension end
 
 """
     module ObsDim

--- a/src/LearnBase.jl
+++ b/src/LearnBase.jl
@@ -345,21 +345,21 @@ module ObsDim
     Default value for most functions. Denotes that the concept of
     an observation dimension is not defined for the given data.
     """
-    immutable Undefined <: ObsDimension end
+    struct Undefined <: ObsDimension end
 
     """
         ObsDim.Last <: ObsDimension
 
     Defines that the last dimension denotes the observations
     """
-    immutable Last <: ObsDimension end
+    struct Last <: ObsDimension end
 
     """
         ObsDim.Constant{DIM} <: ObsDimension
 
     Defines that the dimension `DIM` denotes the observations
     """
-    immutable Constant{DIM} <: ObsDimension end
+    struct Constant{DIM} <: ObsDimension end
     Constant(dim::Int) = Constant{dim}()
 
     """
@@ -398,7 +398,7 @@ default_obsdim(tup::Tuple) = map(default_obsdim, tup)
 import Base: AbstractSet
 
 "A continuous range (inclusive) between a lo and a hi"
-immutable IntervalSet{T} <: AbstractSet{T}
+struct IntervalSet{T} <: AbstractSet{T}
     lo::T
     hi::T
 end
@@ -421,7 +421,7 @@ Base.length{T<:AbstractVector}(s::IntervalSet{T}) = length(s.lo)
 
 
 "Set of discrete items"
-immutable DiscreteSet{T<:AbstractArray} <: AbstractSet{T}
+struct DiscreteSet{T<:AbstractArray} <: AbstractSet{T}
     items::T
 end
 randtype(s::DiscreteSet) = eltype(s.items)
@@ -447,7 +447,7 @@ end
 
 
 "Groups several heterogenous sets. Used mainly for proper dispatch."
-immutable TupleSet{T<:Tuple} <: AbstractSet{T}
+struct TupleSet{T<:Tuple} <: AbstractSet{T}
     sets::T
 end
 TupleSet(sets::AbstractSet...) = TupleSet(sets)

--- a/src/LearnBase.jl
+++ b/src/LearnBase.jl
@@ -432,16 +432,20 @@ Base.getindex(s::DiscreteSet, i::Int) = s.items[i]
 
 
 # operations on arrays of sets
-randtype{S<:AbstractSet,N}(sets::AbstractArray{S,N}) = Array{promote_type(map(randtype, sets)...), N}
-Base.rand{S<:AbstractSet}(sets::AbstractArray{S}) = eltype(randtype(sets))[rand(s) for s in sets]
-function Base.rand{S<:AbstractSet}(sets::AbstractArray{S}, dim1::Integer, dims::Integer...)
+function randtype(sets::AbstractArray{S,N}) where {S<:AbstractSet, N}
+    Array{promote_type(map(randtype, sets)...), N}
+end
+function Base.rand(sets::AbstractArray{S}) where {S<:AbstractSet}
+    eltype(randtype(sets))[rand(s) for s in sets]
+end
+function Base.rand(sets::AbstractArray{S}, dim1::Integer, dims::Integer...) where {S<:AbstractSet}
     A = Array{randtype(sets)}(dim1, dims...)
     for i in eachindex(A)
         A[i] = rand(sets)
     end
     A
 end
-function Base.in{S<:AbstractSet}(xs::AbstractArray, sets::AbstractArray{S})
+function Base.in(xs::AbstractArray, sets::AbstractArray{S}) where {S<:AbstractSet}
     size(xs) == size(sets) && all(map(in, xs, sets))
 end
 
@@ -457,7 +461,7 @@ randtype(sets::TupleSet, ::Type{Vector}) = Vector{promote_type(map(randtype, set
 Base.rand(sets::TupleSet, ::Type{Vector}) = eltype(randtype(sets, Vector))[rand(s) for s in sets.sets]
 randtype(sets::TupleSet, ::Type{Tuple}) = Tuple{map(randtype, sets.sets)...}
 Base.rand(sets::TupleSet, ::Type{Tuple}) = map(rand, sets.sets)
-function Base.rand{OT}(sets::TupleSet, ::Type{OT}, dim1::Integer, dims::Integer...)
+function Base.rand(sets::TupleSet, ::Type{OT}, dim1::Integer, dims::Integer...) where {OT}
     A = Array{randtype(sets, OT)}(dim1, dims...)
     for i in eachindex(A)
         A[i] = rand(sets, OT)

--- a/src/LearnBase.jl
+++ b/src/LearnBase.jl
@@ -402,22 +402,22 @@ struct IntervalSet{T} <: AbstractSet{T}
     lo::T
     hi::T
 end
-function IntervalSet{A,B}(lo::A, hi::B)
+function IntervalSet(lo::A, hi::B) where {A,B}
     T = promote_type(A,B)
     IntervalSet{T}(convert(T,lo), convert(T,hi))
 end
 
 # numeric interval
-randtype{T<:Number}(s::IntervalSet{T}) = Float64
-Base.rand{T<:Number}(s::IntervalSet{T}, dims::Integer...) = rand(dims...) * (s.hi - s.lo) + s.lo
-Base.in{T<:Number}(x::Number, s::IntervalSet{T}) = s.lo <= x <= s.hi
-Base.length{T<:Number}(s::IntervalSet{T}) = 1
+randtype(s::IntervalSet{<:Number}) = Float64
+Base.rand(s::IntervalSet{<:Number}, dims::Integer...) = rand(dims...) * (s.hi - s.lo) + s.lo
+Base.in(x::Number, s::IntervalSet{<:Number}) = s.lo <= x <= s.hi
+Base.length(s::IntervalSet{<:Number}) = 1
 
 # vector of intervals
-randtype{T<:AbstractVector}(s::IntervalSet{T}) = Vector{Float64}
-Base.rand{T<:AbstractVector}(s::IntervalSet{T}) = Float64[rand() * (s.hi[i] - s.lo[i]) + s.lo[i] for i=1:length(s)]
-Base.in{T<:AbstractVector}(x::AbstractVector, s::IntervalSet{T}) = all(i -> s.lo[i] <= x[i] <= s.hi[i], 1:length(s))
-Base.length{T<:AbstractVector}(s::IntervalSet{T}) = length(s.lo)
+randtype(s::IntervalSet{<:AbstractVector}) = Vector{Float64}
+Base.rand(s::IntervalSet{<:AbstractVector}) = Float64[rand() * (s.hi[i] - s.lo[i]) + s.lo[i] for i=1:length(s)]
+Base.in(x::AbstractVector, s::IntervalSet{<:AbstractVector}) = all(i -> s.lo[i] <= x[i] <= s.hi[i], 1:length(s))
+Base.length(s::IntervalSet{<:AbstractVector}) = length(s.lo)
 
 
 "Set of discrete items"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using LearnBase
-using Base.Test
+using Test
 
 # Test if types are exported properly
 @test Cost <: Any
@@ -284,9 +284,6 @@ end
     @test convert(LearnBase.ObsDimension, :null) === ObsDim.Undefined()
     @test convert(LearnBase.ObsDimension, :undefined) === ObsDim.Undefined()
     @test convert(LearnBase.ObsDimension, nothing) === ObsDim.Undefined()
-
-    # TODO: remove test after deprecation phase
-    @test LearnBase.obs_dim(:last) === ObsDim.Last()
 end
 
 struct SomeType end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -112,7 +112,7 @@ using StatsBase
 @test StatsBase.nobs == LearnBase.nobs
 
 # Test superset fallbacks
-immutable MyStronglyConvexType end
+struct MyStronglyConvexType end
 LearnBase.isstronglyconvex(::MyStronglyConvexType) = true
 LearnBase.islipschitzcont(::MyStronglyConvexType) = true
 @test isstronglyconvex(MyStronglyConvexType())
@@ -289,7 +289,7 @@ end
     @test LearnBase.obs_dim(:last) === ObsDim.Last()
 end
 
-immutable SomeType end
+struct SomeType end
 @testset "obsdim default values" begin
     @testset "Arrays, SubArrays, and Sparse Arrays" begin
         @test @inferred(LearnBase.default_obsdim(rand(10))) === ObsDim.Last()


### PR DESCRIPTION
- `immutable` -> `struct`
- Use `where` syntax
- Bump REQUIRE to julia 0.6