### PR TITLE
Quick patch to export ObsDim again

### DIFF
--- a/src/obsdim.jl
+++ b/src/obsdim.jl
@@ -1,3 +1,5 @@
+export ObsDim
+
 """
 Baseclass for all observation dimensions.
 """


### PR DESCRIPTION
Fixes #41. Can I get some guidance on why StatsBase interfaces, like `nobs`, were removed? It is needed to MLDataPattern.jl.