### PR TITLE
Properly display derived types of `AbstractSet` in REPL or IJulia 

### DIFF
--- a/src/other.jl
+++ b/src/other.jl
@@ -239,6 +239,12 @@ Base.rand(s::IntervalSet{T}) where T <: AbstractVector = Float64[rand() * (s.hi[
 Base.in(x::AbstractVector, s::IntervalSet{T}) where T <: AbstractVector = all(i -> s.lo[i] <= x[i] <= s.hi[i], 1:length(s))
 Base.length(s::IntervalSet{T}) where T <: AbstractVector = length(s.lo)
 
+# display in REPL and IJulia
+function Base.show(io::IO, ::MIME"text/plain", s::IntervalSet)
+    println(io, typeof(s), " with endpoints:")
+    println(io, " lo   = ", s.lo)
+    print(io, " high = ", s.hi) 
+end
 
 "Set of discrete items"
 struct DiscreteSet{T<:AbstractArray} <: AbstractSet{T}
@@ -250,7 +256,10 @@ Base.in(x, s::DiscreteSet) = x in s.items
 Base.length(s::DiscreteSet) = length(s.items)
 Base.getindex(s::DiscreteSet, i::Int) = s.items[i]
 Base.:(==)(s1::DiscreteSet, s2::DiscreteSet) = s1.items == s2.items
-
+function Base.show(io::IO, ::MIME"text/plain", s::DiscreteSet)
+    println(io, typeof(s), " with items:")
+    print(io, " ", s.items)
+end
 
 # operations on arrays of sets
 randtype(sets::AbstractArray{S,N}) where {S <: AbstractSet, N} = Array{promote_type(map(randtype, sets)...), N}
@@ -292,6 +301,13 @@ Base.iterate(sets::TupleSet, i) = iterate(sets.sets, i)
 randtype(sets::TupleSet) = randtype(sets, Vector)
 Base.rand(sets::TupleSet, dims::Integer...) = rand(sets, Vector, dims...)
 Base.in(x, sets::TupleSet) = all(map(in, x, sets.sets))
+function Base.show(io::IO, ::MIME"text/plain", s::TupleSet)
+    print(io, typeof(s), " composed of $(length(s.sets)) sets:")
+    for set in s.sets
+        println(io)
+        show(io, "text/plain", set)
+    end
+end
 
 "Returns an AbstractSet representing valid input values"
 function inputdomain end

--- a/test/other.jl
+++ b/test/other.jl
@@ -76,6 +76,8 @@
         end
         @test LearnBase.randtype(s) == Float64
         # @show s LearnBase.randtype(s)
+        @test display(s) === nothing  
+        println()  
     end
     let s = LearnBase.IntervalSet(-1,1.0)
         @test typeof(s) == LearnBase.IntervalSet{Float64}
@@ -83,6 +85,8 @@
         @test 1 in s
         # @show s LearnBase.randtype(s)
         @test length(s) == 1
+        @test display(s) === nothing 
+        println()
     end
 
     # IntervalSet{Vector}
@@ -96,6 +100,8 @@
         @test !([-1.5,0] in s)
         @test !([0,2] in s)
         @test length(s) == 2
+        @test display(s) === nothing 
+        println()
     end
 
     # DiscreteSet
@@ -122,12 +128,16 @@
         @test LearnBase.randtype(s) == Int
         @test length(s) == 2
         @test s[1] == -1
+        @test display(s) === nothing 
+        println()
     end
     let s = LearnBase.DiscreteSet([-1,1.0])
         @test typeof(s) == LearnBase.DiscreteSet{Vector{Float64}}
         @test typeof(s) <: AbstractSet
         @test typeof(rand(s)) == Float64
         @test typeof(rand(s, 2)) == Vector{Float64}
+        @test display(s) === nothing 
+        println()
     end
 
     # TupleSet
@@ -152,6 +162,8 @@
             tot += length(x)
         end
         @test length(s) == tot
+        @test display(s) === nothing 
+        println()
     end
 
     # arrays of sets


### PR DESCRIPTION
Fix #40