### PR TITLE
import StatsBase: nobs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,13 +2,16 @@ name = "LearnBase"
 uuid = "7f8f8fb0-2700-5f03-b4bd-41f8cfc144b6"
 version = "0.5.0"
 
+[deps]
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+
 [compat]
+StatsBase = "0.32, 0.33"
 julia = "1.0"
 
 [extras]
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "SparseArrays", "StatsBase"]
+test = ["Test", "SparseArrays"]

--- a/src/LearnBase.jl
+++ b/src/LearnBase.jl
@@ -1,5 +1,7 @@
 module LearnBase
 
+using StatsBase: nobs
+
 # AGGREGATION MODES
 include("aggmode.jl")
 
@@ -7,7 +9,6 @@ include("aggmode.jl")
 include("iteration.jl")
 
 # OBSERVATION DIMENSIONS
-export default_obsdim, getobs, getobs!
 include("observation.jl")
 
 # LEARNING COSTS (e.g. loss & penalty)

--- a/src/observation.jl
+++ b/src/observation.jl
@@ -38,14 +38,15 @@ implement `StatsBase.nobs`.
 Let's see how to implement a dataset interface for a dataset
 represented by an array:
 ```julia
-using LearnBase, StatsBase
+using LearnBase
 
 function LearnBase.getobs(x::AbstractArray{T,N}, idx; obsdim=default_obsdim(x)) where {T,N}   
     _idx = ntuple(i->  i == obsdim ? idx : Colon(), N)
     return x[_idx...]
 end
 
-StatsBase.nobs(x::AbstractArray; obsdim=default_obsdim(x)) = size(x, obsdim)  
+# LearnBase imports nobs from StatsBase
+LearnBase.nobs(x::AbstractArray; obsdim=default_obsdim(x)) = size(x, obsdim)  
 
 X = rand(2,3)
 

--- a/src/observation.jl
+++ b/src/observation.jl
@@ -62,7 +62,7 @@ LearnBase.getobs(t::Tuple, idx) = getobs.(t, Ref(idx))
 
 # Assume all elements have the same nummber of observations.
 # It would be safer to check explicitely though.
-StatsBase.nobs(t::Tuple) = nobs(t[1])
+LearnBase.nobs(t::Tuple) = nobs(t[1])
 
 # A dataset with 3 observations, each with 2 input features
 X, Y = rand(2, 3), rand(3)

--- a/test/observation.jl
+++ b/test/observation.jl
@@ -1,3 +1,5 @@
+using LearnBase: getobs, nobs, default_obsdim
+
 @test typeof(LearnBase.getobs) <: Function
 @test typeof(LearnBase.getobs!) <: Function
 @test typeof(LearnBase.gettargets) <: Function
@@ -9,7 +11,7 @@
         _idx = ntuple(i->  i == obsdim ? idx : Colon(), N)
         return x[_idx...]
     end
-    StatsBase.nobs(x::AbstractArray; obsdim=default_obsdim(x)) = size(x, obsdim)  
+    LearnBase.nobs(x::AbstractArray; obsdim=default_obsdim(x)) = size(x, obsdim)  
 
     a = rand(2,3)
     @test nobs(a) == 3
@@ -22,7 +24,7 @@
     LearnBase.getobs(t::Tuple, idx) = getobs.(t, Ref(idx))
     # Assume all elements have the same nummber of observations.
     # It would be safer to check explicitely though.
-    StatsBase.nobs(t::Tuple) = nobs(t[1])
+    LearnBase.nobs(t::Tuple) = nobs(t[1])
 
     # A dataset with 3 observations, each with 2 input features
     X, Y = rand(2, 3), rand(3)


### PR DESCRIPTION
Import `StatsBase: noobs` so that downstream packages (such as FastAI.jl) can continue to implement
```julia
LearnBase.nobs(data::MyDataset) = ...
```
without breakage. Since StatsBase is a heavy dependence, I filed https://github.com/JuliaStats/StatsAPI.jl/pull/3 to move `nobs` to StatsAPI.jl. Switching from StatsBase to StatsAPI can be done at a later moment without breackage, this PR shouldn't be blocked by that. 

One tangential consideration: in accordance with these days naming conventions, ideally we should rename

LearnBase -> LearnAPI  (a package containing only (unexported) definitions without the implementations, similar to StatsAPI and DataAPI)

MLDataPattens, MLLabelsUtils, LossFunctions, PenatlyFunction could be condensed into a single MLBase package instead. 


cc @darsnack 